### PR TITLE
Add modular speed detector with H.265 test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-# jetson-carspeed-rstp
+# Jetson Car Speed RTSP
+
+This repository contains a simple example for detecting vehicles from an RTSP stream and logging their estimated speed to a SQLite database. It is intended for NVIDIA Jetson devices but should run on any Linux system with Python.
+
+## Prerequisites
+
+* Python 3.8+
+* [OpenCV](https://pypi.org/project/opencv-python/)
+* [Ultralytics YOLO](https://github.com/ultralytics/ultralytics)
+
+Install dependencies with:
+
+```bash
+pip install opencv-python ultralytics
+```
+
+Download a YOLO model (e.g., `yolov8n.pt`) from the Ultralytics project or train your own.
+
+## Usage
+
+Run the RTSP example and pass your stream URL, YOLO model path, the desired output database path, and the pixel-per-meter (PPM) scale for your camera setup:
+
+```bash
+python carspeed.py --rtsp rtsp://camera/stream --model yolov8n.pt --db vehicles.db --ppm 20
+```
+
+The script will connect to the RTSP stream, detect vehicles in each frame, estimate their speed based on tracked pixel movement, and write the results to an SQLite database called `vehicles.db` by default.
+
+### Testing with an H.265 MP4 file
+
+You can also run the speed detection against a local MP4 file encoded with UniFi's H.265 format. Use the `carspeed_file.py` helper:
+
+```bash
+python carspeed_file.py --video example.mp4 --model yolov8n.pt --db test.db --ppm 20
+```
+
+Make sure your OpenCV build has H.265 support through FFmpeg so the file can be decoded correctly.
+
+The PPM value represents how many pixels correspond to one meter in the scene and must be measured for your specific camera angle.
+
+## Database schema
+
+The `vehicles` table contains:
+
+- `timestamp`: capture time in seconds
+- `track_id`: ID assigned to a tracked vehicle
+- `label`: predicted object class
+- `speed`: estimated speed in meters per second
+- `x1`, `y1`, `x2`, `y2`: bounding box coordinates
+- `confidence`: YOLO confidence score
+
+You can query this SQLite database from other programs to analyze vehicle speeds and counts.

--- a/carspeed.py
+++ b/carspeed.py
@@ -1,0 +1,17 @@
+import argparse
+import cv2
+
+from speed_detector import run_capture
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="RTSP vehicle speed detector")
+    parser.add_argument("--rtsp", required=True, help="RTSP stream URL")
+    parser.add_argument("--model", required=True, help="Path to YOLO model")
+    parser.add_argument("--db", default="vehicles.db", help="Output SQLite DB path")
+    parser.add_argument("--ppm", type=float, required=True, help="Pixels per meter scale")
+    parser.add_argument("--max-distance", type=float, default=50, help="Max pixel distance for tracking")
+    args = parser.parse_args()
+
+    cap = cv2.VideoCapture(args.rtsp)
+    run_capture(cap, args.model, args.db, args.ppm, args.max_distance)

--- a/carspeed_file.py
+++ b/carspeed_file.py
@@ -1,0 +1,17 @@
+import argparse
+import cv2
+
+from speed_detector import run_capture
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="H.265 MP4 speed test")
+    parser.add_argument("--video", required=True, help="Path to MP4 file")
+    parser.add_argument("--model", required=True, help="Path to YOLO model")
+    parser.add_argument("--db", default="vehicles.db", help="Output SQLite DB path")
+    parser.add_argument("--ppm", type=float, required=True, help="Pixels per meter scale")
+    parser.add_argument("--max-distance", type=float, default=50, help="Max pixel distance for tracking")
+    args = parser.parse_args()
+
+    cap = cv2.VideoCapture(args.video)
+    run_capture(cap, args.model, args.db, args.ppm, args.max_distance)

--- a/speed_detector.py
+++ b/speed_detector.py
@@ -1,0 +1,99 @@
+import sqlite3
+import time
+from typing import List, Tuple
+
+import cv2
+from ultralytics import YOLO
+
+
+class VehicleTrack:
+    def __init__(self, center: Tuple[float, float], ts: float):
+        self.center = center
+        self.last_ts = ts
+
+
+class SimpleTracker:
+    def __init__(self, max_distance: float = 50):
+        self.tracks = {}
+        self.next_id = 0
+        self.max_distance = max_distance
+
+    def update(self, detections: List[Tuple[int, int, int, int]], ts: float):
+        matches = {}
+        for box in detections:
+            cx = (box[0] + box[2]) / 2
+            cy = (box[1] + box[3]) / 2
+            matched_id = None
+            for tid, track in self.tracks.items():
+                dist = ((cx - track.center[0]) ** 2 + (cy - track.center[1]) ** 2) ** 0.5
+                if dist < self.max_distance:
+                    matched_id = tid
+                    break
+            if matched_id is None:
+                matched_id = self.next_id
+                self.next_id += 1
+            self.tracks[matched_id] = VehicleTrack((cx, cy), ts)
+            matches[matched_id] = (cx, cy)
+        return matches
+
+
+def init_db(path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS vehicles (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp REAL,
+        track_id INTEGER,
+        label TEXT,
+        speed REAL,
+        x1 INTEGER, y1 INTEGER, x2 INTEGER, y2 INTEGER,
+        confidence REAL
+    )"""
+    )
+    conn.commit()
+    return conn
+
+
+def run_capture(cap: cv2.VideoCapture, model_path: str, db_path: str, ppm: float, max_distance: float = 50):
+    model = YOLO(model_path)
+    conn = init_db(db_path)
+    tracker = SimpleTracker(max_distance)
+    prev_positions = {}
+
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        ts = time.time()
+        detections = []
+        results = model(frame)
+        for r in results:
+            for box in r.boxes:
+                cls = int(box.cls[0])
+                if cls not in [2, 5, 7]:
+                    continue  # vehicle classes
+                x1, y1, x2, y2 = map(int, box.xyxy[0])
+                detections.append((x1, y1, x2, y2, float(box.conf[0]), r.names[cls]))
+        boxes = [d[:4] for d in detections]
+        assignments = tracker.update(boxes, ts)
+        for (x1, y1, x2, y2, conf, label), (track_id, center) in zip(detections, assignments.items()):
+            speed = 0.0
+            if track_id in prev_positions:
+                px, py, pts = prev_positions[track_id]
+                dist_pix = ((center[0] - px) ** 2 + (center[1] - py) ** 2) ** 0.5
+                dist_m = dist_pix / ppm
+                dt = ts - pts
+                if dt > 0:
+                    speed = dist_m / dt  # m/s
+            prev_positions[track_id] = (center[0], center[1], ts)
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO vehicles(timestamp, track_id, label, speed, x1, y1, x2, y2, confidence)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (ts, track_id, label, speed, x1, y1, x2, y2, conf),
+            )
+            conn.commit()
+
+    cap.release()
+    conn.close()


### PR DESCRIPTION
## Summary
- factor out vehicle tracking and database logic into `speed_detector.py`
- modify `carspeed.py` to use the new module for RTSP streams
- add `carspeed_file.py` to test videos encoded with H.265/MP4
- update README with instructions for the new video test option

## Testing
- `python -m py_compile speed_detector.py carspeed.py carspeed_file.py`


------
https://chatgpt.com/codex/tasks/task_e_685f14918974832eb331f976aeb0db4e