### PR TITLE
Add .gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+.pytest_cache/
+libspeedtrack.so
+*.db
+*.o


### PR DESCRIPTION
## Summary
- ignore Python cache folders, pytest cache, and compiled artifacts

## Testing
- `python -m py_compile deepstream_speed.py`

------
https://chatgpt.com/codex/tasks/task_e_685f2e1176c0832e94b031752912b3d8