### PR TITLE
Fix Makefile recipe and update build docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+PLUGIN=libspeedtrack.so
+PLUGIN_SRC=speed_plugin.c
+PKGS=$(shell pkg-config --cflags --libs gstreamer-1.0 gstreamer-base-1.0)
+LIBS=$(PKGS) -lnvds_meta -lsqlite3 -lm
+CFLAGS=-Wall -fPIC -shared
+CC=gcc
+
+$(PLUGIN): $(PLUGIN_SRC)
+	$(CC) $(CFLAGS) $(PLUGIN_SRC) -o $(PLUGIN) $(LIBS)
+
+clean:
+	rm -f $(PLUGIN) *.o

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Compile `speed_plugin.c` into a shared object and place it in a location searche
 ```bash
 gcc -Wall -fPIC -shared speed_plugin.c -o libspeedtrack.so \
   $(pkg-config --cflags --libs gstreamer-1.0 gstreamer-base-1.0) \
-  -lnvds_meta -lsqlite3
+  -lnvds_meta -lsqlite3 -lm
 export GST_PLUGIN_PATH=$PWD:$GST_PLUGIN_PATH
 ```
 


### PR DESCRIPTION
## Summary
- add missing Makefile with correct recipe tabbing
- link math library in the build instructions and Makefile

## Testing
- `python -m py_compile deepstream_speed.py`
- `make` *(fails: `gst/gst.h` not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f30b902a8832ebe4105ec1d6c424c