### PR TITLE
Add coverage for common build artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 __pycache__/
+*.pyc
 .pytest_cache/
-libspeedtrack.so
+*.so
 *.db
 *.o
+# Editor backups
+*~
+*.swp
+# macOS files
+.DS_Store


### PR DESCRIPTION
## Summary
- update `.gitignore` to ignore Python bytecode, pytest cache, compiled artifacts and other temporary files

## Testing
- `make` *(fails: no makefile)*
- `python -m py_compile deepstream_speed.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f30c57060832ea8c5c534cf62d766