### PR TITLE
Update README with testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,14 @@ The plug-in writes rows to the `vehicles` table containing:
 - `speed` – estimated speed in meters per second
 
 Use standard SQLite tools to analyse the results.
+
+## Development
+
+Run the unit tests with `pytest -q`:
+
+```bash
+pytest -q
+```
+
+Some tests rely on GStreamer and DeepStream. If these dependencies are not
+available, they will be skipped.


### PR DESCRIPTION
## Summary
- document running tests with `pytest -q`
- note GStreamer-dependent tests may be skipped

## Testing
- `make` *(fails: no makefile)*
- `python -m py_compile deepstream_speed.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f30cbdd98832ea263e605b0f7250a