### PR TITLE
Add homography support for speed estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ python deepstream_speed.py --video sample.mp4 \
 ```
 
 `--ppm` is the pixel-per-meter scale for your camera view. Speeds are written to the SQLite database specified with `--db`.
+Use `--homography` to load a 3×3 matrix from a JSON or YAML file if coordinates
+need to be mapped before speed calculation.
 
 ## nvinfer configuration
 

--- a/carspeed.py
+++ b/carspeed.py
@@ -1,7 +1,7 @@
 import argparse
 import cv2
 
-from speed_detector import run_capture
+from speed_detector import run_capture, load_homography
 
 
 if __name__ == "__main__":
@@ -11,7 +11,9 @@ if __name__ == "__main__":
     parser.add_argument("--db", default="vehicles.db", help="Output SQLite DB path")
     parser.add_argument("--ppm", type=float, required=True, help="Pixels per meter scale")
     parser.add_argument("--max-distance", type=float, default=50, help="Max pixel distance for tracking")
+    parser.add_argument("--homography", help="Path to 3x3 homography JSON/YAML")
     args = parser.parse_args()
 
     cap = cv2.VideoCapture(args.rtsp)
-    run_capture(cap, args.model, args.db, args.ppm, args.max_distance)
+    H = load_homography(args.homography) if args.homography else None
+    run_capture(cap, args.model, args.db, args.ppm, args.max_distance, H)

--- a/carspeed_file.py
+++ b/carspeed_file.py
@@ -1,7 +1,7 @@
 import argparse
 import cv2
 
-from speed_detector import run_capture
+from speed_detector import run_capture, load_homography
 
 
 if __name__ == "__main__":
@@ -11,7 +11,9 @@ if __name__ == "__main__":
     parser.add_argument("--db", default="vehicles.db", help="Output SQLite DB path")
     parser.add_argument("--ppm", type=float, required=True, help="Pixels per meter scale")
     parser.add_argument("--max-distance", type=float, default=50, help="Max pixel distance for tracking")
+    parser.add_argument("--homography", help="Path to 3x3 homography JSON/YAML")
     args = parser.parse_args()
 
     cap = cv2.VideoCapture(args.video)
-    run_capture(cap, args.model, args.db, args.ppm, args.max_distance)
+    H = load_homography(args.homography) if args.homography else None
+    run_capture(cap, args.model, args.db, args.ppm, args.max_distance, H)

--- a/deepstream_speed.py
+++ b/deepstream_speed.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
 """DeepStream-based car speed detection pipeline."""
 import argparse
+import json
 import gi
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - PyYAML may be missing
+    yaml = None
 
 
 gi.require_version('Gst', '1.0')
@@ -10,16 +16,42 @@ from gi.repository import Gst, GLib
 Gst.init(None)
 
 
-def build_pipeline(uri: str, config: str, db: str, ppm: float, is_rtsp: bool) -> Gst.Pipeline:
+def load_homography(path: str):
+    if not path:
+        return None
+    with open(path, "r") as f:
+        if yaml and path.endswith((".yml", ".yaml")):
+            data = yaml.safe_load(f)
+        else:
+            data = json.load(f)
+    flat = [float(v) for row in data for v in row]
+    if len(flat) != 9:
+        raise ValueError("homography must have 9 values")
+    return flat
+
+
+def build_pipeline(
+    uri: str,
+    config: str,
+    db: str,
+    ppm: float,
+    is_rtsp: bool,
+    homography=None,
+) -> Gst.Pipeline:
     if is_rtsp:
         src = f"rtspsrc location={uri} latency=100 ! rtph265depay ! h265parse ! nvv4l2decoder"
     else:
         src = f"filesrc location={uri} ! qtdemux ! h265parse ! nvv4l2decoder"
 
+    homography_str = (
+        " " + "homography=" + ",".join(str(v) for v in homography)
+        if homography
+        else ""
+    )
     pipe_desc = (
         f"{src} ! nvstreammux name=mux batch-size=1 width=1280 height=720 ! "
         f"nvinfer config-file-path={config} ! nvtracker ! "
-        f"speedtrack ppm={ppm} db={db} ! fakesink sync=false"
+        f"speedtrack ppm={ppm} db={db}{homography_str} ! fakesink sync=false"
     )
     return Gst.parse_launch(pipe_desc)
 
@@ -32,10 +64,12 @@ def main() -> None:
     parser.add_argument("--config", default="ds_config.txt", help="nvinfer config file")
     parser.add_argument("--db", default="vehicles.db", help="SQLite DB path")
     parser.add_argument("--ppm", type=float, required=True, help="Pixels per meter")
+    parser.add_argument("--homography", help="Path to 3x3 homography JSON/YAML")
     args = parser.parse_args()
 
     uri = args.rtsp if args.rtsp else args.video
-    pipeline = build_pipeline(uri, args.config, args.db, args.ppm, args.rtsp is not None)
+    H = load_homography(args.homography) if args.homography else None
+    pipeline = build_pipeline(uri, args.config, args.db, args.ppm, args.rtsp is not None, H)
     bus = pipeline.get_bus()
     pipeline.set_state(Gst.State.PLAYING)
 

--- a/speed_detector.py
+++ b/speed_detector.py
@@ -1,6 +1,12 @@
 import sqlite3
 import time
-from typing import List, Tuple
+from typing import List, Tuple, Optional
+import json
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - PyYAML may be missing
+    yaml = None
 
 import cv2
 from ultralytics import YOLO
@@ -37,6 +43,20 @@ class SimpleTracker:
         return matches
 
 
+def load_homography(path: str) -> Optional[List[float]]:
+    if not path:
+        return None
+    with open(path, "r") as f:
+        if yaml and path.endswith((".yml", ".yaml")):
+            data = yaml.safe_load(f)
+        else:
+            data = json.load(f)
+    flat = [float(v) for row in data for v in row]
+    if len(flat) != 9:
+        raise ValueError("homography must have 9 values")
+    return flat
+
+
 def init_db(path: str) -> sqlite3.Connection:
     conn = sqlite3.connect(path)
     cur = conn.cursor()
@@ -55,7 +75,14 @@ def init_db(path: str) -> sqlite3.Connection:
     return conn
 
 
-def run_capture(cap: cv2.VideoCapture, model_path: str, db_path: str, ppm: float, max_distance: float = 50):
+def run_capture(
+    cap: cv2.VideoCapture,
+    model_path: str,
+    db_path: str,
+    ppm: float,
+    max_distance: float = 50,
+    homography: Optional[List[float]] = None,
+):
     model = YOLO(model_path)
     conn = init_db(db_path)
     tracker = SimpleTracker(max_distance)
@@ -78,15 +105,23 @@ def run_capture(cap: cv2.VideoCapture, model_path: str, db_path: str, ppm: float
         boxes = [d[:4] for d in detections]
         assignments = tracker.update(boxes, ts)
         for (x1, y1, x2, y2, conf, label), (track_id, center) in zip(detections, assignments.items()):
+            cx, cy = center
+            if homography:
+                tx = homography[0] * cx + homography[1] * cy + homography[2]
+                ty = homography[3] * cx + homography[4] * cy + homography[5]
+                tz = homography[6] * cx + homography[7] * cy + homography[8]
+                if tz != 0:
+                    cx = tx / tz
+                    cy = ty / tz
             speed = 0.0
             if track_id in prev_positions:
                 px, py, pts = prev_positions[track_id]
-                dist_pix = ((center[0] - px) ** 2 + (center[1] - py) ** 2) ** 0.5
+                dist_pix = ((cx - px) ** 2 + (cy - py) ** 2) ** 0.5
                 dist_m = dist_pix / ppm
                 dt = ts - pts
                 if dt > 0:
                     speed = dist_m / dt  # m/s
-            prev_positions[track_id] = (center[0], center[1], ts)
+            prev_positions[track_id] = (cx, cy, ts)
             cur = conn.cursor()
             cur.execute(
                 "INSERT INTO vehicles(timestamp, track_id, label, speed, x1, y1, x2, y2, confidence)"


### PR DESCRIPTION
## Summary
- support optional homography matrix in `speedtrack` plugin and Python utilities
- add `--homography` CLI option to speed tools
- transform coordinates with the matrix before distance calculations
- document new option in README

## Testing
- `python -m py_compile deepstream_speed.py`
- `make` *(fails: gstreamer headers missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686042b671c4832e82247cba4d6737c2