### PR TITLE
Add homography calibration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,26 @@ need to be mapped before speed calculation.
 `--window` controls how many observations are used to smooth the speed
 measurement.
 
+## Calibrating the homography
+
+The helper script `calibrate_homography.py` can generate the transformation
+matrix for your camera view:
+
+```bash
+# grab a frame from an RTSP stream
+python calibrate_homography.py --rtsp rtsp://camera/stream \
+  --width 3.5 --length 20
+
+# or load an existing image
+python calibrate_homography.py --image frame.jpg \
+  --width 3.5 --length 20
+```
+
+Click the four lane corners starting from the near left and proceeding clockwise
+(left-front, right-front, right-rear, left-rear). The script saves
+`homography.json`, which can be supplied to `deepstream_speed.py` via
+`--homography`.
+
 ## nvinfer configuration
 
 `ds_config.txt` is a minimal configuration for an INT8 TensorRT-optimized YOLOv8l engine. Replace `model-engine-file` with your preferred engine if needed.

--- a/calibrate_homography.py
+++ b/calibrate_homography.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Interactive homography calibration tool."""
+
+import argparse
+import json
+from typing import List
+
+import cv2
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Calibrate homography from four points")
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument("--image", help="Path to input image")
+    src.add_argument("--rtsp", help="RTSP URL to grab a frame")
+    parser.add_argument("--width", type=float, required=True, help="Real-world lane width in meters")
+    parser.add_argument("--length", type=float, required=True, help="Real-world lane length in meters")
+    parser.add_argument("--output", default="homography.json", help="Output JSON file for matrix")
+    return parser.parse_args()
+
+
+class PointCollector:
+    def __init__(self, frame):
+        self.frame = frame
+        self.view = frame.copy()
+        self.points: List[List[int]] = []
+
+    def callback(self, event, x, y, flags, param):
+        if event == cv2.EVENT_LBUTTONDOWN and len(self.points) < 4:
+            self.points.append([x, y])
+            cv2.circle(self.view, (x, y), 5, (0, 0, 255), -1)
+            cv2.imshow("frame", self.view)
+
+
+def collect_points(frame) -> List[List[int]]:
+    collector = PointCollector(frame)
+    cv2.imshow("frame", frame)
+    cv2.setMouseCallback("frame", collector.callback)
+    while len(collector.points) < 4:
+        if cv2.waitKey(10) == 27:  # ESC to cancel
+            break
+    cv2.destroyAllWindows()
+    return collector.points
+
+
+def main() -> None:
+    args = parse_args()
+    if args.image:
+        frame = cv2.imread(args.image)
+        if frame is None:
+            raise FileNotFoundError(args.image)
+    else:
+        cap = cv2.VideoCapture(args.rtsp)
+        ret, frame = cap.read()
+        cap.release()
+        if not ret:
+            raise RuntimeError("Failed to grab frame from RTSP")
+
+    pts = collect_points(frame)
+    if len(pts) != 4:
+        print("Need four points to compute homography")
+        return
+
+    src_pts = cv2.float32(pts)
+    dst_pts = cv2.float32(
+        [
+            [0, 0],
+            [args.width, 0],
+            [args.width, args.length],
+            [0, args.length],
+        ]
+    )
+    H, _ = cv2.findHomography(src_pts, dst_pts)
+    if H is None:
+        raise RuntimeError("Could not compute homography")
+    data = [[float(v) for v in row] for row in H]
+    with open(args.output, "w") as f:
+        json.dump(data, f, indent=2)
+    print(f"Saved homography to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `calibrate_homography.py` to create homography matrices interactively
- document calibration workflow in the README

## Testing
- `make` *(fails: gstreamer headers missing)*
- `pytest -q`
- `python -m py_compile deepstream_speed.py`


------
https://chatgpt.com/codex/tasks/task_e_686049973044832ebf374e09f3e53c6f