### PR TITLE
Replace SimpleTracker with ByteTrack tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ The plug-in writes rows to the `vehicles` table containing:
 
 Use standard SQLite tools to analyse the results.
 
+## Standalone Python tracker
+
+The helper scripts `carspeed.py` and `carspeed_file.py` provide a lightweight
+pipeline using a simple ByteTrack implementation. The tracker behaviour can be
+configured with:
+
+* `--iou-threshold` – IoU required to associate a detection with an existing
+  track (default `0.3`).
+* `--decay-time` – time in seconds to keep a track alive when detections are
+  missing (default `1.0`).
+
+These scripts are useful for quick experiments without a full DeepStream setup.
+
 ## Development
 
 Run the unit tests with `pytest -q`:

--- a/carspeed.py
+++ b/carspeed.py
@@ -10,10 +10,11 @@ if __name__ == "__main__":
     parser.add_argument("--model", required=True, help="Path to YOLO model")
     parser.add_argument("--db", default="vehicles.db", help="Output SQLite DB path")
     parser.add_argument("--ppm", type=float, required=True, help="Pixels per meter scale")
-    parser.add_argument("--max-distance", type=float, default=50, help="Max pixel distance for tracking")
+    parser.add_argument("--iou-threshold", type=float, default=0.3, help="Detection IoU threshold")
+    parser.add_argument("--decay-time", type=float, default=1.0, help="Seconds to keep lost tracks")
     parser.add_argument("--homography", help="Path to 3x3 homography JSON/YAML")
     args = parser.parse_args()
 
     cap = cv2.VideoCapture(args.rtsp)
     H = load_homography(args.homography) if args.homography else None
-    run_capture(cap, args.model, args.db, args.ppm, args.max_distance, H)
+    run_capture(cap, args.model, args.db, args.ppm, args.iou_threshold, args.decay_time, H)

--- a/carspeed_file.py
+++ b/carspeed_file.py
@@ -10,10 +10,11 @@ if __name__ == "__main__":
     parser.add_argument("--model", required=True, help="Path to YOLO model")
     parser.add_argument("--db", default="vehicles.db", help="Output SQLite DB path")
     parser.add_argument("--ppm", type=float, required=True, help="Pixels per meter scale")
-    parser.add_argument("--max-distance", type=float, default=50, help="Max pixel distance for tracking")
+    parser.add_argument("--iou-threshold", type=float, default=0.3, help="Detection IoU threshold")
+    parser.add_argument("--decay-time", type=float, default=1.0, help="Seconds to keep lost tracks")
     parser.add_argument("--homography", help="Path to 3x3 homography JSON/YAML")
     args = parser.parse_args()
 
     cap = cv2.VideoCapture(args.video)
     H = load_homography(args.homography) if args.homography else None
-    run_capture(cap, args.model, args.db, args.ppm, args.max_distance, H)
+    run_capture(cap, args.model, args.db, args.ppm, args.iou_threshold, args.decay_time, H)

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from tracker import ByteTracker
+
+
+def test_bytracker_id_persistence():
+    tracker = ByteTracker(iou_threshold=0.1, decay_time=1.0)
+    first = tracker.update([(0, 0, 10, 10)], 0.0)
+    tid = next(iter(first))
+    # no detection frame within decay time
+    tracker.update([], 0.5)
+    second = tracker.update([(1, 1, 11, 11)], 0.6)
+    assert tid in second
+
+
+def test_bytracker_expiry():
+    tracker = ByteTracker(iou_threshold=0.1, decay_time=0.5)
+    first = tracker.update([(0, 0, 10, 10)], 0.0)
+    tid = next(iter(first))
+    tracker.update([], 1.0)
+    second = tracker.update([(0, 0, 10, 10)], 1.1)
+    assert list(second.keys())[0] != tid

--- a/tracker.py
+++ b/tracker.py
@@ -1,0 +1,62 @@
+from typing import List, Tuple
+
+
+class VehicleTrack:
+    def __init__(self, box: Tuple[int, int, int, int], ts: float, tid: int):
+        self.box = box
+        self.last_ts = ts
+        self.id = tid
+        self.center = ((box[0] + box[2]) / 2, (box[1] + box[3]) / 2)
+
+
+def _iou(box_a: Tuple[int, int, int, int], box_b: Tuple[int, int, int, int]) -> float:
+    x1 = max(box_a[0], box_b[0])
+    y1 = max(box_a[1], box_b[1])
+    x2 = min(box_a[2], box_b[2])
+    y2 = min(box_a[3], box_b[3])
+    if x2 <= x1 or y2 <= y1:
+        return 0.0
+    inter = float((x2 - x1) * (y2 - y1))
+    area_a = float((box_a[2] - box_a[0]) * (box_a[3] - box_a[1]))
+    area_b = float((box_b[2] - box_b[0]) * (box_b[3] - box_b[1]))
+    return inter / (area_a + area_b - inter)
+
+
+class ByteTracker:
+    """Very small ByteTrack-inspired tracker."""
+
+    def __init__(self, iou_threshold: float = 0.3, decay_time: float = 1.0):
+        self.iou_threshold = iou_threshold
+        self.decay_time = decay_time
+        self.tracks = []
+        self.next_id = 0
+
+    def update(self, detections: List[Tuple[int, int, int, int]], ts: float):
+        # remove expired tracks
+        self.tracks = [t for t in self.tracks if ts - t.last_ts <= self.decay_time]
+
+        assignments = {}
+        used = set()
+        for box in detections:
+            best_iou = self.iou_threshold
+            best_track = None
+            for track in self.tracks:
+                if track in used:
+                    continue
+                iou = _iou(box, track.box)
+                if iou > best_iou:
+                    best_iou = iou
+                    best_track = track
+            if best_track is None:
+                tid = self.next_id
+                self.next_id += 1
+                best_track = VehicleTrack(box, ts, tid)
+                self.tracks.append(best_track)
+            else:
+                best_track.box = box
+                best_track.center = ((box[0] + box[2]) / 2, (box[1] + box[3]) / 2)
+                best_track.last_ts = ts
+            used.add(best_track)
+            assignments[best_track.id] = best_track.center
+        return assignments
+


### PR DESCRIPTION
## Summary
- switch to a lightweight ByteTrack implementation
- expose tracker parameters via `--iou-threshold` and `--decay-time`
- document tracker flags in README
- add unit tests covering tracker persistence

## Testing
- `pytest -q`
- `make` *(fails: gstreamer headers missing)*
- `python -m py_compile deepstream_speed.py`


------
https://chatgpt.com/codex/tasks/task_e_68604d96cc8c832eb0005fd22d5e88b6