### PR TITLE
Add logging features

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ need to be mapped before speed calculation.
 measurement.
 `--batch-size` sets the number of streams processed together by `nvstreammux` and
 `--resize` allows specifying the processing resolution as `WIDTHxHEIGHT`.
+`--log-level` controls Python logging verbosity (e.g. `DEBUG`). The C plug-in
+uses the GStreamer debug system and can be enabled with `GST_DEBUG`.
 
 ## Calibrating the homography
 
 The helper script `calibrate_homography.py` can generate the transformation
-matrix for your camera view:
+matrix for your camera view. Logging output follows the Python logging level:
 
 ```bash
 # grab a frame from an RTSP stream

--- a/calibrate_homography.py
+++ b/calibrate_homography.py
@@ -3,6 +3,7 @@
 
 import argparse
 import json
+import logging
 from typing import List
 
 import cv2
@@ -45,6 +46,7 @@ def collect_points(frame) -> List[List[int]]:
 
 def main() -> None:
     args = parse_args()
+    logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)
     if args.image:
         frame = cv2.imread(args.image)
         if frame is None:
@@ -58,7 +60,7 @@ def main() -> None:
 
     pts = collect_points(frame)
     if len(pts) != 4:
-        print("Need four points to compute homography")
+        logging.error("Need four points to compute homography")
         return
 
     src_pts = cv2.float32(pts)
@@ -76,7 +78,7 @@ def main() -> None:
     data = [[float(v) for v in row] for row in H]
     with open(args.output, "w") as f:
         json.dump(data, f, indent=2)
-    print(f"Saved homography to {args.output}")
+    logging.info("Saved homography to %s", args.output)
 
 
 if __name__ == "__main__":

--- a/calibrate_homography.py
+++ b/calibrate_homography.py
@@ -4,6 +4,8 @@
 import argparse
 import json
 import logging
+
+logger = logging.getLogger(__name__)
 from typing import List
 
 import cv2
@@ -60,7 +62,7 @@ def main() -> None:
 
     pts = collect_points(frame)
     if len(pts) != 4:
-        logging.error("Need four points to compute homography")
+        logger.error("Need four points to compute homography")
         return
 
     src_pts = cv2.float32(pts)
@@ -78,7 +80,7 @@ def main() -> None:
     data = [[float(v) for v in row] for row in H]
     with open(args.output, "w") as f:
         json.dump(data, f, indent=2)
-    logging.info("Saved homography to %s", args.output)
+    logger.info("Saved homography to %s", args.output)
 
 
 if __name__ == "__main__":

--- a/deepstream_speed.py
+++ b/deepstream_speed.py
@@ -2,6 +2,7 @@
 """DeepStream-based car speed detection pipeline."""
 import argparse
 import json
+import logging
 import gi
 
 try:
@@ -76,7 +77,10 @@ def main() -> None:
     parser.add_argument("--window", type=int, default=3, help="History window size")
     parser.add_argument("--batch-size", type=int, default=1, help="nvstreammux batch size")
     parser.add_argument("--resize", help="Resize as WIDTHxHEIGHT for nvstreammux")
+    parser.add_argument("--log-level", default="INFO", help="Logging level")
     args = parser.parse_args()
+    logging.basicConfig(format="%(levelname)s:%(message)s",
+                        level=getattr(logging, args.log_level.upper(), logging.INFO))
     if not args.engine.endswith(".trt"):
         parser.error("--engine must specify a .trt file")
 
@@ -104,6 +108,7 @@ def main() -> None:
     )
     bus = pipeline.get_bus()
     pipeline.set_state(Gst.State.PLAYING)
+    logging.info("Pipeline started")
 
     try:
         while True:
@@ -116,6 +121,7 @@ def main() -> None:
         pass
 
     pipeline.set_state(Gst.State.NULL)
+    logging.info("Pipeline stopped")
 
 
 if __name__ == "__main__":

--- a/deepstream_speed.py
+++ b/deepstream_speed.py
@@ -3,6 +3,8 @@
 import argparse
 import json
 import logging
+
+logger = logging.getLogger(__name__)
 import gi
 
 try:
@@ -108,7 +110,7 @@ def main() -> None:
     )
     bus = pipeline.get_bus()
     pipeline.set_state(Gst.State.PLAYING)
-    logging.info("Pipeline started")
+    logger.info("Pipeline started")
 
     try:
         while True:
@@ -121,7 +123,7 @@ def main() -> None:
         pass
 
     pipeline.set_state(Gst.State.NULL)
-    logging.info("Pipeline stopped")
+    logger.info("Pipeline stopped")
 
 
 if __name__ == "__main__":

--- a/speed_plugin.c
+++ b/speed_plugin.c
@@ -5,6 +5,9 @@
 #include <sqlite3.h>
 #include <math.h>
 
+GST_DEBUG_CATEGORY_STATIC(gst_speed_debug);
+#define GST_CAT_DEFAULT gst_speed_debug
+
 typedef struct {
   gdouble x;
   gdouble y;
@@ -167,12 +170,14 @@ static gboolean gst_speed_start(GstBaseTransform *trans) {
   GstSpeed *speed = (GstSpeed *)trans;
   if (sqlite3_open(speed->db_path, &speed->db) != SQLITE_OK) {
     g_printerr("Could not open DB %s\n", speed->db_path);
+    GST_DEBUG_OBJECT(speed, "failed to open DB %s", speed->db_path);
     speed->db = NULL;
   } else {
     sqlite3_exec(speed->db,
                  "CREATE TABLE IF NOT EXISTS vehicles (timestamp REAL, track_id INTEGER, speed REAL);",
                  NULL, NULL, NULL);
     speed->sql_batch = g_string_new(NULL);
+    GST_DEBUG_OBJECT(speed, "opened DB %s", speed->db_path);
   }
   speed->history = g_hash_table_new_full(g_int64_hash, g_int64_equal, NULL,
                                          history_free);
@@ -215,8 +220,10 @@ static GstFlowReturn gst_speed_transform_ip(GstBaseTransform *trans, GstBuffer *
         sqlite3_free(sql);
       }
     }
-    if (speed->sql_batch->len > 0)
+    if (speed->sql_batch->len > 0) {
       sqlite3_exec(speed->db, speed->sql_batch->str, NULL, NULL, NULL);
+      GST_DEBUG_OBJECT(speed, "executed SQL batch: %s", speed->sql_batch->str);
+    }
   }
   return GST_FLOW_OK;
 }
@@ -255,6 +262,7 @@ static void gst_speed_init(GstSpeed *speed) {
 }
 
 static gboolean plugin_init(GstPlugin *plugin) {
+  GST_DEBUG_CATEGORY_INIT(gst_speed_debug, "speedtrack", 0, "speedtrack plugin");
   return gst_element_register(plugin, "speedtrack", GST_RANK_NONE, gst_speed_get_type());
 }
 


### PR DESCRIPTION
## Summary
- switch calibrate_homography.py to `logging`
- add `--log-level` option to deepstream_speed.py
- log when pipeline starts/stops
- add debug category to speed_plugin.c and log DB operations
- document new logging options in README

## Testing
- `make` *(fails: gstreamer headers missing)*
- `pytest -q`
- `python -m py_compile deepstream_speed.py`

------
https://chatgpt.com/codex/tasks/task_e_6860887ea670832ea81ace5349aa5291