### PR TITLE
Fix undefined PACKAGE macro in speed_plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository demonstrates a DeepStream pipeline for measuring vehicle speed f
 * GObject introspection bindings (PyGObject)
 * SQLite development libraries for building the plug-in
 * `libgstreamer1.0-dev` and `libgstreamer-plugins-base1.0-dev` to compile the plug-in
+  (install with `sudo apt-get install -y libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev` on Ubuntu)
 
 ## Installation
 

--- a/speed_plugin.c
+++ b/speed_plugin.c
@@ -1,5 +1,8 @@
 #include <gst/gst.h>
 #include <gst/base/gstbasetransform.h>
+#ifndef PACKAGE
+#define PACKAGE "speedtrack"
+#endif
 #ifdef HAVE_NVDS
 #include <nvds_meta.h>
 #include <nvds_meta_schema.h>


### PR DESCRIPTION
## Summary
- define fallback value for `PACKAGE` macro when building `speed_plugin.c`
- document how to install GStreamer headers

## Testing
- `make clean && make`
- `pytest -q`
- `python -m py_compile deepstream_speed.py`


------
https://chatgpt.com/codex/tasks/task_e_6860cedf0e3c832eaaa0208370f497d9