### PR TITLE
CLI: load homography (JSON/YAML) and inject .trt into nvinfer config

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ python calibrate_homography.py --image frame.jpg \
 Click the four lane corners starting from the near left and proceeding clockwise
 (left-front, right-front, right-rear, left-rear). The script saves
 `homography.json`, which can be supplied to `deepstream_speed.py` via
-`--homography`.
+`--homography`. The CLI loads JSON/YAML homography files and passes the
+flattened 3x3 matrix to the `speedtrack` plug-in.
 The script outputs progress using Python's `logging` module and honours
 the `--log-level` setting.
 
@@ -80,7 +81,7 @@ homography matrix.
 
 ## nvinfer configuration
 
-`ds_config.txt` does not include an engine file. Download the pre-built TrafficCamNet engine from NGC or create one with the TAO converter, then provide its path via `--engine`. Use this option as well if you retrain a detector and build a new `.trt` file.
+`ds_config.txt` does not include an engine file. Download the pre-built TrafficCamNet engine from NGC or create one with the TAO converter, then provide its path via `--engine`. At runtime the CLI copies the nvinfer config to a temporary file and fills in `model-engine-file` with the supplied `.trt` path. Use this option as well if you retrain a detector and build a new `.trt` file.
 
 ## Retraining with NVIDIA TAO
 

--- a/carspeed/cli.py
+++ b/carspeed/cli.py
@@ -3,8 +3,16 @@
 from __future__ import annotations
 
 import argparse
+import json
 import logging
+import tempfile
+from pathlib import Path
 from typing import Iterable, Optional
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - PyYAML is optional
+    yaml = None
 
 
 logger = logging.getLogger(__name__)
@@ -32,6 +40,65 @@ def build_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def load_homography(path: str) -> str:
+    """Return a 3x3 homography file as a comma-separated matrix string."""
+    with open(path, "r", encoding="utf-8") as fh:
+        if Path(path).suffix.lower() in {".yml", ".yaml"}:
+            if yaml is None:
+                raise RuntimeError("PyYAML is required to read YAML homography files")
+            data = yaml.safe_load(fh)
+        else:
+            data = json.load(fh)
+
+    if isinstance(data, dict):
+        data = data.get("homography") or data.get("matrix") or data.get("H")
+    if data is None:
+        raise ValueError("homography file must contain a 3x3 matrix")
+
+    flat = []
+    for row in data:
+        if isinstance(row, (list, tuple)):
+            flat.extend(row)
+        else:
+            flat.append(row)
+    if len(flat) != 9:
+        raise ValueError("homography must have 9 values")
+    return ",".join(str(float(value)) for value in flat)
+
+
+def write_engine_config(config_path: str, engine_path: str) -> str:
+    """Copy an nvinfer config and set its model-engine-file entry."""
+    source = Path(config_path)
+    lines = source.read_text(encoding="utf-8").splitlines()
+    output = []
+    replaced = False
+    in_property = False
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_property = stripped == "[property]"
+        if in_property and stripped.startswith("model-engine-file="):
+            output.append(f"model-engine-file={engine_path}")
+            replaced = True
+        else:
+            output.append(line)
+
+    if not replaced:
+        insert_at = 0
+        for idx, line in enumerate(output):
+            if line.strip() == "[property]":
+                insert_at = idx + 1
+                break
+        output.insert(insert_at, f"model-engine-file={engine_path}")
+
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".txt", prefix="carspeed-nvinfer-", delete=False, encoding="utf-8"
+    ) as fh:
+        fh.write("\n".join(output) + "\n")
+        return fh.name
+
+
 def main(argv: Optional[Iterable[str]] = None) -> None:
     """Parse arguments and run the pipeline."""
     parser = build_arg_parser()
@@ -51,18 +118,21 @@ def main(argv: Optional[Iterable[str]] = None) -> None:
         w, h = args.resize.split("x", 1)
         width, height = int(w), int(h)
 
+    config = write_engine_config(args.config, args.engine)
+    homography = None if args.homography is None else load_homography(args.homography)
+
     from gi.repository import Gst  # imported after argument parsing
     from .pipeline.config import PipelineOptions
     from .pipeline.deepstream_graph import build_pipeline
 
     opts = PipelineOptions(
         uri=args.rtsp if args.rtsp else args.video,
-        config=args.config,
+        config=config,
         engine=args.engine,
         db=args.db,
         ppm=args.ppm,
         is_rtsp=args.rtsp is not None,
-        homography=None if args.homography is None else args.homography,
+        homography=homography,
         window=args.window,
         batch_size=args.batch_size,
         width=width,

--- a/tests/test_deepstream_speed.py
+++ b/tests/test_deepstream_speed.py
@@ -2,6 +2,7 @@ import sys
 import os
 import types
 import pytest
+import json
 
 # Add project root to path and stub gi
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -29,8 +30,10 @@ def test_engine_suffix_required(monkeypatch):
         deepstream_speed.main()
 
 
-def test_engine_passed_to_pipeline(monkeypatch):
+def test_engine_passed_to_pipeline(monkeypatch, tmp_path):
     captured = {}
+    config = tmp_path / "ds_config.txt"
+    config.write_text("[property]\nmodel-engine-file=\nbatch-size=1\n")
 
     class DummyGst:
         class State:
@@ -45,6 +48,7 @@ def test_engine_passed_to_pipeline(monkeypatch):
 
     def fake_build_pipeline(opts, *a, **kw):
         captured["engine"] = opts.engine
+        captured["config"] = opts.config
 
         class DummyBus:
             def timed_pop_filtered(self, *args, **kwargs):
@@ -72,6 +76,8 @@ def test_engine_passed_to_pipeline(monkeypatch):
             "v.mp4",
             "--ppm",
             "1",
+            "--config",
+            str(config),
             "--engine",
             "model.trt",
         ],
@@ -79,3 +85,34 @@ def test_engine_passed_to_pipeline(monkeypatch):
 
     deepstream_speed.main()
     assert captured["engine"] == "model.trt"
+    assert (
+        "model-engine-file=model.trt"
+        in open(captured["config"], encoding="utf-8").read()
+    )
+
+
+def test_load_homography_flattens_json(tmp_path):
+    homography = tmp_path / "homography.json"
+    homography.write_text(json.dumps([[1, 0, 2], [0, 1, 3], [0, 0, 1]]))
+
+    assert (
+        deepstream_speed.load_homography(str(homography))
+        == "1.0,0.0,2.0,0.0,1.0,3.0,0.0,0.0,1.0"
+    )
+
+
+def test_load_homography_rejects_wrong_shape(tmp_path):
+    homography = tmp_path / "bad.json"
+    homography.write_text(json.dumps([[1, 0], [0, 1]]))
+
+    with pytest.raises(ValueError, match="9 values"):
+        deepstream_speed.load_homography(str(homography))
+
+
+def test_write_engine_config_inserts_missing_property(tmp_path):
+    config = tmp_path / "config.txt"
+    config.write_text("[property]\nbatch-size=1\n")
+
+    generated = deepstream_speed.write_engine_config(str(config), "custom.trt")
+
+    assert "model-engine-file=custom.trt" in open(generated, encoding="utf-8").read()


### PR DESCRIPTION
### Motivation

- Allow users to provide homography files in JSON or YAML and have the CLI convert them into the flattened 3x3 matrix string needed by the `speedtrack` plug-in.
- Ensure the nvinfer config used at runtime contains the correct `model-engine-file` pointing to the supplied TensorRT `.trt` engine so users can supply a custom engine without editing the original config.

### Description

- Implemented `load_homography(path)` which reads JSON or YAML homography files, extracts a 3x3 matrix (keys `homography`, `matrix`, or `H` are recognized), flattens it and returns a comma-separated 9-value string. 
- Added optional YAML support with a guarded import of `yaml` and an explicit error when YAML is required but not installed.
- Implemented `write_engine_config(config_path, engine_path)` which copies an nvinfer config into a temporary file and injects or replaces the `model-engine-file=` entry with the provided `.trt` path, returning the temp filename.
- Integrated both helpers into the CLI: the runtime now uses the generated temporary nvinfer config and passes the flattened homography string to `PipelineOptions`.
- Updated `README.md` to document that the CLI copies the nvinfer config at runtime and fills `model-engine-file`, and that homography JSON/YAML files are supported and passed as a flattened matrix.

### Testing

- Ran the unit tests in `tests/test_deepstream_speed.py` which exercise engine validation, config injection, and homography loading (`test_engine_suffix_required`, `test_engine_passed_to_pipeline`, `test_load_homography_flattens_json`, `test_load_homography_rejects_wrong_shape`, and `test_write_engine_config_inserts_missing_property`).
- All tests were executed with `pytest` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a7e84db40832ea0826b7ac1574b7b)